### PR TITLE
Update readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,3 +7,14 @@ This is my personal `.tmux` directory setup which contains my `.tmux.conf` and a
     cd ~/
     git clone git@github.com:cyphactor/dottmux.git ~/.tmux
     ln -s ~/.tmux/tmux.conf ~/.tmux.conf
+
+## Known issues
+
+If tmux exits with [exited] on Mac Os X you need to install
+`reattach-to-user-namespace` via Homebrew
+
+```
+brew install reattach-to-user-namespace
+```
+
+


### PR DESCRIPTION
Updated readme to include known issue of tmux exiting unless
`reattach-to-user-namespace` is installed. This was included to ease
setup.