### PR TITLE
Add switching between two latest windows

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -39,6 +39,10 @@ bind -n C-k if-shell "$is_vim" "send-keys C-k" "select-pane -U"
 bind -n C-l if-shell "$is_vim" "send-keys C-l" "select-pane -R"
 bind -n C-\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
 
+# Switch between two latests windows
+set-option -g prefix C-b
+bind-key C-b last-window
+
 # Map the H,J,K,L keys to handle resizing of panes
 bind H resize-pane -L 2
 bind J resize-pane -D 1


### PR DESCRIPTION
Adds ability to switch between two latest tmux windows using the
keyboard shortcut `Ctrl+b`. This was added to provide a better workflow.